### PR TITLE
Align items with new type model

### DIFF
--- a/client/src/context/inventory.tsx
+++ b/client/src/context/inventory.tsx
@@ -18,10 +18,10 @@ export type OtherKey =
 
 export type ContainerKey = 'zaino' | 'grid5x5' | OtherKey;
 
-export type ItemKind = 'alimento' | 'indumento' | 'arma' | 'generico';
+export type ItemKind = 'alimento' | 'risorsa' | 'arma';
 export type DamageType = 'contundente' | 'chimico' | 'termico' | 'perforante';
 
-type BaseMeta = { description: string; tier: 1 | 2 | 3; kind: ItemKind };
+type BaseMeta = { description: string; kind: ItemKind; tier?: 1 | 2 | 3 };
 type FoodMeta = BaseMeta & {
   kind: 'alimento';
   isGluten?: boolean;
@@ -30,21 +30,17 @@ type FoodMeta = BaseMeta & {
   isVegetable?: boolean;
   isAlcohol?: boolean;
   isDrugs?: boolean;
-  consumption?: 'mangiare' | 'bere';
+  isFood?: boolean;
+  isDrink?: boolean;
   effectPercent?: number;
-};
-type ClothingMeta = BaseMeta & {
-  kind: 'indumento';
-  protezione?: number;
-  effect?: string;
 };
 type WeaponMeta = BaseMeta & {
   kind: 'arma';
   danno?: number;
-  munizioni?: number;
+  projectiles?: string;
   damageType?: DamageType;
 };
-type GenericMeta = BaseMeta & { kind: 'generico' };
+type ResourceMeta = BaseMeta & { kind: 'risorsa' };
 
 export type Item = {
   id: string;
@@ -55,7 +51,7 @@ export type Item = {
   y: number;
   w: number;
   h: number;
-} & (FoodMeta | ClothingMeta | WeaponMeta | GenericMeta);
+} & (FoodMeta | WeaponMeta | ResourceMeta);
 
 /** ------ Context shape ------ */
 type InventoryContextValue = {

--- a/client/src/hooks/useFauna.ts
+++ b/client/src/hooks/useFauna.ts
@@ -15,9 +15,15 @@ export type BaseItem = {
   tier3Cost: number;
   isGluten: boolean;
   isSugar: boolean;
-  isRedMeat: boolean;
+  isMeat: boolean;
+  isVegetable: boolean;
   isAlcohol: boolean;
-  isDrug: boolean;
+  isDrugs: boolean;
+  isFood: boolean;
+  isDrink: boolean;
+  effectPercent: number;
+  projectileType: string | null;
+  damageType: string | null;
   dmgModifier: number;
   inventoryHeight: number;
   inventoryWidth: number;
@@ -92,9 +98,15 @@ const defaultFauna: Fauna = {
     tier3Cost: 0,
     isGluten: false,
     isSugar: false,
-    isRedMeat: true,
+    isMeat: true,
+    isVegetable: false,
     isAlcohol: false,
-    isDrug: false,
+    isDrugs: false,
+    isFood: true,
+    isDrink: false,
+    effectPercent: 0,
+    projectileType: null,
+    damageType: null,
     dmgModifier: 0,
     inventoryHeight: 1,
     inventoryWidth: 1,

--- a/client/src/routes/crafting.tsx
+++ b/client/src/routes/crafting.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useMemo, useState, useRef } from "react";
-import { FaCubes, FaTshirt, FaFistRaised, FaAppleAlt, FaEraser, FaFillDrip, FaVial, FaSearch, FaCheck, FaSuitcase } from "react-icons/fa";
+import { FaCubes, FaFistRaised, FaAppleAlt, FaEraser, FaFillDrip, FaVial, FaSearch, FaCheck, FaSuitcase } from "react-icons/fa";
 import CommandStreamRight from "../components/commandstream-right";
 
 // Catalog/recipe types
-type ItemType = "risorsa" | "indumento" | "arma" | "alimento";
+type ItemType = "risorsa" | "arma" | "alimento";
 type RecipePart = { name: string; count: number };
 type Craftable = {
   name: string;
@@ -15,7 +15,7 @@ type Craftable = {
 };
 
 // Inventory store types (subset aligned with routes/inventory)
-type InvItemKind = "alimento" | "indumento" | "arma" | "generico";
+type InvItemKind = "alimento" | "arma" | "risorsa";
 type InvItem = {
   id: string;
   name: string;
@@ -58,7 +58,7 @@ const CRAFTABLES: Craftable[] = [
   },
   {
     name: "Pelle Rinforzata",
-    type: "indumento",
+    type: "risorsa",
     icon: "/pelle.png",
     w: 2,
     h: 2,
@@ -92,7 +92,7 @@ const CRAFTABLES: Craftable[] = [
   // Debug items with various sizes
   {
     name: "Armatura Completa",
-    type: "indumento", 
+    type: "risorsa", 
     icon: "/pelle.png",
     w: 3,
     h: 4,
@@ -118,7 +118,7 @@ const CRAFTABLES: Craftable[] = [
   },
   {
     name: "Scudo Grande",
-    type: "indumento",
+    type: "risorsa",
     icon: "/roccia.png",
     w: 3,
     h: 3,
@@ -139,7 +139,7 @@ const CRAFTABLES: Craftable[] = [
   },
   {
     name: "Armatura Leggera",
-    type: "indumento",
+    type: "risorsa",
     icon: "/pelle.png",
     w: 2,
     h: 3,
@@ -192,7 +192,7 @@ const CRAFTABLES: Craftable[] = [
   },
   {
     name: "Armatura Pesante",
-    type: "indumento",
+    type: "risorsa",
     icon: "/roccia.png",
     w: 3,
     h: 4,
@@ -214,7 +214,7 @@ const CRAFTABLES: Craftable[] = [
   },
   {
     name: "Scudo Medio",
-    type: "indumento",
+    type: "risorsa",
     icon: "/roccia.png",
     w: 2,
     h: 2,
@@ -257,7 +257,7 @@ const CRAFTABLES: Craftable[] = [
   },
   {
     name: "Casco",
-    type: "indumento",
+    type: "risorsa",
     icon: "/roccia.png",
     w: 1,
     h: 1,
@@ -267,7 +267,7 @@ const CRAFTABLES: Craftable[] = [
   },
   {
     name: "Torre Scudo",
-    type: "indumento",
+    type: "risorsa",
     icon: "/roccia.png",
     w: 2,
     h: 4,
@@ -313,7 +313,7 @@ const slugify = (name: string) =>
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");
 
-const mapTypeToKind = (t: ItemType): InvItemKind => (t === "risorsa" ? "generico" : (t as InvItemKind));
+const mapTypeToKind = (t: ItemType): InvItemKind => t as InvItemKind;
 
 const loadInventories = (): InventoriesStore => {
   try {
@@ -464,11 +464,14 @@ export default function Crafting() {
   // Mapping delle icone per ogni tipo di item
   const getIconForType = (type: ItemType) => {
     switch (type) {
-      case "risorsa": return <FaCubes />;
-      case "indumento": return <FaTshirt />;
-      case "arma": return <FaFistRaised />;
-      case "alimento": return <FaAppleAlt />;
-      default: return <FaCubes />;
+      case "risorsa":
+        return <FaCubes />;
+      case "arma":
+        return <FaFistRaised />;
+      case "alimento":
+        return <FaAppleAlt />;
+      default:
+        return <FaCubes />;
     }
   };
 
@@ -476,7 +479,14 @@ export default function Crafting() {
   const totalTiles = GRID_COLS * GRID_ROWS;
 
   // Debug helpers: fill inventory with test items to try crafting
-  function addItemToZaino(next: InventoriesStore, name: string, icon: string, w: number, h: number, kind: InvItemKind = "generico") {
+  function addItemToZaino(
+    next: InventoriesStore,
+    name: string,
+    icon: string,
+    w: number,
+    h: number,
+    kind: InvItemKind = "risorsa",
+  ) {
     const pos = findPlacement(next.zaino || [], w, h);
     if (!pos) return false;
     const id = `${slugify(name)}-${Math.random().toString(36).slice(2, 8)}`;
@@ -502,9 +512,9 @@ export default function Crafting() {
       const next: InventoriesStore = { ...prev, zaino: [...(prev.zaino || [])] };
       // Try to place a variety of items until near capacity
       const batches: Array<{ name: string; icon: string; w: number; h: number; kind?: InvItemKind; count: number }> = [
-        { name: "Roccia", icon: "/roccia.png", w: 2, h: 2, kind: "generico", count: 6 },
-        { name: "Pelle", icon: "/pelle.png", w: 1, h: 1, kind: "indumento", count: 8 },
-        { name: "Ossa", icon: "/ossa.png", w: 1, h: 1, kind: "generico", count: 6 },
+        { name: "Roccia", icon: "/roccia.png", w: 2, h: 2, kind: "risorsa", count: 6 },
+        { name: "Pelle", icon: "/pelle.png", w: 1, h: 1, kind: "risorsa", count: 8 },
+        { name: "Ossa", icon: "/ossa.png", w: 1, h: 1, kind: "risorsa", count: 6 },
         { name: "Bastone Acuminato", icon: "/bastoneacuminato.png", w: 1, h: 5, kind: "arma", count: 1 },
       ];
       for (const b of batches) {
@@ -965,7 +975,7 @@ export default function Crafting() {
             }}
           />
         </div>
-        {(["risorsa", "indumento", "arma", "alimento"] as ItemType[]).map((t) => (
+        {(["risorsa", "arma", "alimento"] as ItemType[]).map((t) => (
           <button
             key={t}
             onClick={() => setFilter((f) => (f === t ? null : t))}

--- a/client/src/routes/inventory.tsx
+++ b/client/src/routes/inventory.tsx
@@ -12,8 +12,8 @@ import {
 import { BACKEND_IP, BACKEND_PORT } from '../common';
 import { useUser } from '../context/user';
 
-type ItemKind = 'alimento' | 'indumento' | 'arma' | 'generico';
-type BaseMeta = { description: string; tier: 1 | 2 | 3; kind: ItemKind };
+type ItemKind = 'alimento' | 'risorsa' | 'arma';
+type BaseMeta = { description: string; kind: ItemKind; tier?: 1 | 2 | 3 };
 type FoodMeta = BaseMeta & {
   kind: 'alimento';
   isGluten?: boolean;
@@ -22,22 +22,18 @@ type FoodMeta = BaseMeta & {
   isVegetable?: boolean;
   isAlcohol?: boolean;
   isDrugs?: boolean;
-  consumption?: 'mangiare' | 'bere';
+  isFood?: boolean;
+  isDrink?: boolean;
   effectPercent?: number;
-};
-type ClothingMeta = BaseMeta & {
-  kind: 'indumento';
-  protezione?: number;
-  effect?: string;
 };
 type DamageType = 'contundente' | 'chimico' | 'termico' | 'perforante';
 type WeaponMeta = BaseMeta & {
   kind: 'arma';
   danno?: number;
-  munizioni?: number;
+  projectiles?: string;
   damageType?: DamageType;
 };
-type GenericMeta = BaseMeta & { kind: 'generico' };
+type ResourceMeta = BaseMeta & { kind: 'risorsa' };
 
 type Item = {
   id: string;
@@ -48,7 +44,7 @@ type Item = {
   y: number;
   w: number;
   h: number;
-} & (FoodMeta | ClothingMeta | WeaponMeta | GenericMeta);
+} & (FoodMeta | WeaponMeta | ResourceMeta);
 
 // ---- dynamic specs for "others" coming from backend ----
 type InvCategory = 'zaino' | 'cassa';
@@ -1229,13 +1225,17 @@ export default function Inventory() {
                     valueFontSize={VALUE_FS}
                     padding={PAD}
                   >
-                    {Array.from({ length: selectedItem.tier }).map((_, i) => (
-                      <FaStar
-                        key={i}
-                        color='#dfffff'
-                        style={{ marginLeft: 4 }}
-                      />
-                    ))}
+                    {selectedItem.tier ? (
+                      Array.from({ length: selectedItem.tier }).map((_, i) => (
+                        <FaStar
+                          key={i}
+                          color='#dfffff'
+                          style={{ marginLeft: 4 }}
+                        />
+                      ))
+                    ) : (
+                      <span style={{ fontWeight: 700 }}>—</span>
+                    )}
                   </Slot>
                   {selectedItem.kind === 'alimento' && (
                     <>
@@ -1281,61 +1281,39 @@ export default function Inventory() {
                         padding={PAD}
                       >
                         {typeof selectedItem.effectPercent === 'number' ? (
-                          <div
-                            style={{
-                              display: 'flex',
-                              alignItems: 'center',
-                              gap: 6,
-                            }}
-                          >
-                            {selectedItem.consumption === 'bere' ? (
-                              <img
-                                src='/droplet_fill.png'
-                                alt='Sete'
-                                width={ICON_SIZE}
-                                height={ICON_SIZE}
-                              />
-                            ) : (
-                              <img
-                                src='/stomach-fill.png'
-                                alt='Fame'
-                                width={ICON_SIZE}
-                                height={ICON_SIZE}
-                              />
-                            )}
-                            <span style={{ fontWeight: 700 }}>
-                              {selectedItem.effectPercent}%
-                            </span>
-                          </div>
+                          (() => {
+                            const drink = selectedItem.isDrink ?? false;
+                            const food = selectedItem.isFood ?? false;
+                            const hasIcon = drink || food;
+                            const iconSrc = drink
+                              ? '/droplet_fill.png'
+                              : '/stomach-fill.png';
+                            const iconAlt = drink ? 'Sete' : 'Fame';
+                            return (
+                              <div
+                                style={{
+                                  display: 'flex',
+                                  alignItems: 'center',
+                                  gap: 6,
+                                }}
+                              >
+                                {hasIcon ? (
+                                  <img
+                                    src={iconSrc}
+                                    alt={iconAlt}
+                                    width={ICON_SIZE}
+                                    height={ICON_SIZE}
+                                  />
+                                ) : null}
+                                <span style={{ fontWeight: 700 }}>
+                                  {selectedItem.effectPercent}%
+                                </span>
+                              </div>
+                            );
+                          })()
                         ) : (
                           <span style={{ fontWeight: 700 }}>—</span>
                         )}
-                      </Slot>
-                    </>
-                  )}
-                  {selectedItem.kind === 'indumento' && (
-                    <>
-                      <Slot
-                        label='Protezione'
-                        width={W}
-                        labelFontSize={LABEL_FS}
-                        valueFontSize={VALUE_FS}
-                        padding={PAD}
-                      >
-                        <span style={{ fontWeight: 700 }}>
-                          {selectedItem.protezione ?? 0}
-                        </span>
-                      </Slot>
-                      <Slot
-                        label='Effetto'
-                        width={W}
-                        labelFontSize={LABEL_FS}
-                        valueFontSize={VALUE_FS}
-                        padding={PAD}
-                      >
-                        <span style={{ fontWeight: 700 }}>
-                          {selectedItem.effect ?? '—'}
-                        </span>
                       </Slot>
                     </>
                   )}
@@ -1372,19 +1350,19 @@ export default function Inventory() {
                         </div>
                       </Slot>
                       <Slot
-                        label='Munizioni'
+                        label='Proiettili'
                         width={W}
                         labelFontSize={LABEL_FS}
                         valueFontSize={VALUE_FS}
                         padding={PAD}
                       >
                         <span style={{ fontWeight: 700 }}>
-                          {selectedItem.munizioni ?? 0}
+                          {selectedItem.projectiles ?? '—'}
                         </span>
                       </Slot>
                     </>
                   )}
-                  {selectedItem.kind === 'generico' && (
+                  {selectedItem.kind === 'risorsa' && (
                     <>
                       <Slot
                         label='Info'

--- a/client/src/routes/user.tsx
+++ b/client/src/routes/user.tsx
@@ -14,14 +14,14 @@ import {
   faLungs,
   faMoon,
   faHeartPulse,
-  faShirt,
   faGun,
   faRotateLeft,
+  faSuitcase,
 } from '@fortawesome/free-solid-svg-icons';
 // import MonitorWidget from "../components/monitorwidget"; // non usato qui, mostriamo soli valori
 
 // Minimal re-use of inventory item types and helpers (aligned with inventory/crafting)
-type InvItemKind = 'alimento' | 'indumento' | 'arma' | 'generico';
+type InvItemKind = 'alimento' | 'arma' | 'risorsa';
 type InvItem = {
   id: string;
   name: string;
@@ -159,7 +159,7 @@ export default function User({
           id: 'test-outfit-1',
           name: 'Tuta Spaziale',
           icon: '/zaino.png',
-          kind: 'indumento',
+          kind: 'risorsa',
           x: 0,
           y: 1,
           w: 2,
@@ -171,7 +171,7 @@ export default function User({
           id: 'test-outfit-2',
           name: 'Armatura',
           icon: '/pelle.png',
-          kind: 'indumento',
+          kind: 'risorsa',
           x: 2,
           y: 1,
           w: 2,
@@ -191,7 +191,7 @@ export default function User({
   const zaino = inventories.zaino || [];
   const weapons = useMemo(() => zaino.filter(i => i.kind === 'arma'), [zaino]);
   const outfits = useMemo(
-    () => zaino.filter(i => i.kind === 'indumento'),
+    () => zaino.filter(i => i.kind === 'risorsa'),
     [zaino],
   );
   const usedTiles = useMemo(
@@ -213,8 +213,8 @@ export default function User({
   function equipItem(slot: 'left' | 'right' | 'outfit', item: InvItem) {
     setError(null);
     // validate kind for slot
-    if (slot === 'outfit' && item.kind !== 'indumento') {
-      setError('Solo indumenti possono essere equipaggiati nello slot Outfit.');
+    if (slot === 'outfit' && item.kind !== 'risorsa') {
+      setError('Solo risorse compatibili possono essere equipaggiate nello slot Outfit.');
       return;
     }
     if ((slot === 'left' || slot === 'right') && item.kind !== 'arma') {
@@ -521,7 +521,7 @@ export default function User({
     item?: InvItem | null;
     onPick: () => void;
     onUnequip: () => void;
-    kind: 'arma' | 'indumento';
+    kind: 'arma' | 'risorsa';
   }) {
     return (
       <div
@@ -625,7 +625,7 @@ export default function User({
                 fontSize: 24,
               }}
             >
-              <FontAwesomeIcon icon={kind === 'arma' ? faGun : faShirt} />
+              <FontAwesomeIcon icon={kind === 'arma' ? faGun : faSuitcase} />
             </div>
             <div
               onMouseUp={e => {
@@ -857,7 +857,7 @@ export default function User({
           >
             <Slot
               label='Outfit'
-              kind='indumento'
+              kind='risorsa'
               item={equip.outfit}
               onPick={() => openPicker('outfit')}
               onUnequip={() => unequipItem('outfit')}
@@ -931,7 +931,7 @@ export default function User({
             >
               <strong>
                 Seleziona{' '}
-                {picker!.slot === 'outfit' ? 'un indumento' : "un'arma"}
+                {picker!.slot === 'outfit' ? 'una risorsa' : "un'arma"}
               </strong>
               <button
                 onClick={() => setPicker(null)}

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -41,6 +41,8 @@ export const baseItemsTable = sqliteTable("baseItems", {
     .notNull(),
   image: text().notNull(), // link (relativo) all'immagine, es. /img/items/egg
   description: text().notNull(), // Può contenere HTML
+  inventoryWidth: int().notNull(),
+  inventoryHeight: int().notNull(),
   tier1Value: int().default(0),
   tier1Cost: int().default(0),
   tier2Value: int().default(0),
@@ -49,12 +51,16 @@ export const baseItemsTable = sqliteTable("baseItems", {
   tier3Cost: int().default(0),
   isGluten: int().default(0),
   isSugar: int().default(0),
-  isRedMeat: int().default(0),
+  isMeat: int().default(0),
+  isVegetable: int().default(0),
   isAlcohol: int().default(0),
-  isDrug: int().default(0),
+  isDrugs: int().default(0),
+  isFood: int().default(0),
+  isDrink: int().default(0),
+  effectPercent: int().default(0),
+  projectileType: text(),
+  damageType: text(),
   dmgModifier: real().default(0),
-  inventoryHeight: int().notNull(),
-  inventoryWidth: int().notNull(),
 });
 
 export const itemsTable = sqliteTable("items", {


### PR DESCRIPTION
## Summary
- extend base item schema to capture resource/food/weapon specific attributes and new projectile metadata
- update shared inventory data structures and fauna hook to expose the new item fields
- refresh crafting, inventory, and user UIs to operate on the alimento/risorsa/arma type model

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e0192bd4f0832c810c36d2a7a75133