### PR TITLE
Add GM console and control endpoints

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,6 +9,7 @@ import {
 import HomePage from './components/homepage';
 import LoginPage from './routes/login';
 import MonitorWidget from './components/monitorwidget';
+import GMOverlay from './components/gmOverlay';
 import Inventory from './routes/inventory';
 import Database from './routes/database';
 import Crafting from './routes/crafting';
@@ -773,6 +774,8 @@ export default function App() {
           element={isAuthed ? <Dossier /> : <Navigate to='/' replace />}
         />
       </Routes>
+
+      <GMOverlay />
 
       {/* Overlay di benvenuto dopo login */}
       {showWelcome && (

--- a/client/src/components/gmOverlay.tsx
+++ b/client/src/components/gmOverlay.tsx
@@ -1,0 +1,355 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+
+import { BACKEND_IP, BACKEND_PORT } from '../common';
+import { useUser } from '../context/user';
+
+type GmPlayer = {
+  name: string;
+  hunger: number;
+  thirst: number;
+  sleep: number;
+  oxygen: number;
+  energy: number;
+  biofeedback: number;
+  temperature: number;
+  isRobot: number;
+  isSick: number;
+  inventory: Array<{
+    id: string;
+    name: string;
+    icon?: string;
+    w?: number;
+    h?: number;
+  }>;
+};
+
+type StatProps = {
+  label: string;
+  value: number;
+  color: string;
+};
+
+const StatBar: React.FC<StatProps> = ({ label, value, color }) => {
+  const pct = useMemo(() => Math.max(0, Math.min(100, value)), [value]);
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+      <div style={{ fontSize: 11, letterSpacing: 1, textTransform: 'uppercase' }}>
+        {label}
+      </div>
+      <div
+        style={{
+          height: 6,
+          width: '100%',
+          background: 'rgba(255,255,255,0.08)',
+          borderRadius: 4,
+          overflow: 'hidden',
+        }}
+        aria-hidden
+      >
+        <div
+          style={{
+            width: `${pct}%`,
+            height: '100%',
+            background: color,
+            transition: 'width 0.3s ease',
+          }}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default function GMOverlay() {
+  const { user, revision } = useUser();
+  const isGm = Boolean(user?.isGm);
+  const gmName = user?.name ?? null;
+
+  const [players, setPlayers] = useState<GmPlayer[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [command, setCommand] = useState('');
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [transferring, setTransferring] = useState<string | null>(null);
+
+  const fetchState = useCallback(async () => {
+    if (!isGm || !gmName) return;
+    try {
+      const res = await fetch(
+        `http://${BACKEND_IP}:${BACKEND_PORT}/gm/state?name=${encodeURIComponent(
+          gmName,
+        )}`,
+      );
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = (await res.json()) as { players?: GmPlayer[] };
+      setPlayers(data.players ?? []);
+      setError(null);
+    } catch (err: any) {
+      console.error('GM state error', err);
+      setError(err?.message ?? 'Errore di rete');
+    }
+  }, [gmName, isGm]);
+
+  useEffect(() => {
+    if (!isGm) return;
+    fetchState();
+  }, [fetchState, isGm, revision]);
+
+  useEffect(() => {
+    if (!isGm) return;
+    const id = window.setInterval(() => fetchState(), 5000);
+    return () => window.clearInterval(id);
+  }, [fetchState, isGm]);
+
+  const sendCommand = useCallback(async () => {
+    if (!command.trim() || !gmName) return;
+    setLoading(true);
+    setFeedback(null);
+    try {
+      const res = await fetch(`http://${BACKEND_IP}:${BACKEND_PORT}/gm/command`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: gmName, command }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error((data as any)?.error ?? `HTTP ${res.status}`);
+      }
+      setFeedback((data as any)?.message ?? 'Comando eseguito');
+      setCommand('');
+      fetchState();
+    } catch (err: any) {
+      console.error('GM command error', err);
+      setFeedback(err?.message ?? 'Errore comando');
+    } finally {
+      setLoading(false);
+    }
+  }, [command, fetchState, gmName]);
+
+  const handleTransfer = useCallback(
+    async (from: string, itemId: string) => {
+      if (!gmName) return;
+      setTransferring(itemId);
+      setFeedback(null);
+      try {
+        const res = await fetch(`http://${BACKEND_IP}:${BACKEND_PORT}/gm/transfer`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: gmName, from, itemId }),
+        });
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) {
+          throw new Error((data as any)?.error ?? `HTTP ${res.status}`);
+        }
+        setFeedback((data as any)?.message ?? 'Item trasferito');
+        fetchState();
+      } catch (err: any) {
+        console.error('GM transfer error', err);
+        setFeedback(err?.message ?? 'Errore trasferimento');
+      } finally {
+        setTransferring(null);
+      }
+    },
+    [fetchState, gmName],
+  );
+
+  if (!isGm || !gmName) return null;
+
+  const others = players.filter(p => p.name !== gmName);
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        bottom: 24,
+        left: 24,
+        width: 360,
+        maxHeight: '70vh',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 12,
+        padding: 16,
+        background: 'rgba(6, 18, 32, 0.88)',
+        border: '1px solid rgba(79,198,255,0.35)',
+        borderRadius: 12,
+        boxShadow: '0 18px 32px rgba(0,0,0,0.45)',
+        color: '#dfffff',
+        fontFamily: 'Eurostile, sans-serif',
+        zIndex: 4000,
+        backdropFilter: 'blur(6px)',
+        overflow: 'hidden',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <div style={{ fontSize: 12, letterSpacing: 2, opacity: 0.8 }}>
+          GM CONSOLE
+        </div>
+        {loading && (
+          <div style={{ fontSize: 11, color: '#9fb8c7' }}>esecuzione…</div>
+        )}
+      </div>
+      <div style={{ display: 'flex', gap: 8 }}>
+        <input
+          value={command}
+          onChange={e => setCommand(e.target.value)}
+          onKeyDown={e => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              sendCommand();
+            }
+          }}
+          placeholder='Inserisci comando GM…'
+          style={{
+            flex: 1,
+            background: 'rgba(12, 30, 48, 0.85)',
+            border: '1px solid rgba(79,198,255,0.28)',
+            borderRadius: 6,
+            padding: '8px 10px',
+            color: '#dfffff',
+            fontFamily: 'Eurostile, sans-serif',
+            fontSize: 13,
+          }}
+        />
+        <button
+          onClick={sendCommand}
+          disabled={loading || !command.trim()}
+          style={{
+            padding: '8px 12px',
+            background: 'linear-gradient(135deg, #2fc8ff, #167bff)',
+            border: 'none',
+            borderRadius: 6,
+            color: '#041520',
+            fontWeight: 700,
+            fontSize: 12,
+            letterSpacing: 1,
+            cursor: 'pointer',
+            opacity: loading || !command.trim() ? 0.6 : 1,
+          }}
+        >
+          INVIA
+        </button>
+      </div>
+      {feedback && (
+        <div style={{ fontSize: 12, color: '#9be7ff', minHeight: 18 }}>{feedback}</div>
+      )}
+      {error && (
+        <div style={{ fontSize: 12, color: '#ff8686', minHeight: 18 }}>{error}</div>
+      )}
+      <div
+        style={{
+          overflowY: 'auto',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 12,
+          paddingRight: 4,
+        }}
+      >
+        {others.length === 0 && (
+          <div style={{ fontSize: 12, color: '#9fb8c7' }}>
+            Nessun altro giocatore collegato.
+          </div>
+        )}
+        {others.map(player => (
+          <div
+            key={player.name}
+            style={{
+              border: '1px solid rgba(79,198,255,0.18)',
+              borderRadius: 10,
+              padding: 10,
+              background: 'rgba(8, 26, 42, 0.6)',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 8,
+            }}
+          >
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                fontSize: 13,
+                letterSpacing: 1,
+                textTransform: 'uppercase',
+              }}
+            >
+              <span>{player.name}</span>
+              <span style={{ fontSize: 11, color: player.isSick ? '#ff8787' : '#9fb8c7' }}>
+                {player.isSick ? 'PATOLOGIA' : 'OK'}
+              </span>
+            </div>
+            <StatBar label='Fame' value={player.hunger} color='#50fa7b' />
+            <StatBar label='Sete' value={player.thirst} color='#57d7ff' />
+            <StatBar label='Sonno' value={player.sleep} color='#d4b9ff' />
+            <StatBar label='Ossigeno' value={player.oxygen} color='#ffa257' />
+            {player.isRobot ? (
+              <StatBar label='Energia' value={player.energy} color='#ffd257' />
+            ) : (
+              <StatBar label='Biofeedback' value={player.biofeedback} color='#ff6b9a' />
+            )}
+            {player.inventory.length > 0 && (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                <div style={{ fontSize: 11, opacity: 0.75, letterSpacing: 1 }}>
+                  Inventario
+                </div>
+                <div
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+                    gap: 6,
+                  }}
+                >
+                  {player.inventory.slice(0, 8).map(item => (
+                    <button
+                      key={item.id}
+                      onClick={() => handleTransfer(player.name, item.id)}
+                      disabled={transferring === item.id}
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 6,
+                        padding: '6px 8px',
+                        background: 'rgba(12, 34, 52, 0.85)',
+                        border: '1px solid rgba(79,198,255,0.22)',
+                        borderRadius: 6,
+                        color: '#dfffff',
+                        fontSize: 11,
+                        cursor: 'pointer',
+                        opacity: transferring && transferring !== item.id ? 0.5 : 1,
+                      }}
+                    >
+                      {item.icon && (
+                        <img
+                          src={item.icon}
+                          alt={item.name}
+                          style={{
+                            width: 20,
+                            height: 20,
+                            objectFit: 'contain',
+                            filter: 'drop-shadow(0 2px 4px rgba(0,0,0,0.35))',
+                          }}
+                          onError={e => {
+                            (e.currentTarget as HTMLImageElement).style.display = 'none';
+                          }}
+                        />
+                      )}
+                      <span style={{ flex: 1, textAlign: 'left' }}>{item.name}</span>
+                    </button>
+                  ))}
+                </div>
+                {player.inventory.length > 8 && (
+                  <div style={{ fontSize: 10, color: '#9fb8c7' }}>
+                    … {player.inventory.length - 8} altri oggetti
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/client/src/context/inventory.tsx
+++ b/client/src/context/inventory.tsx
@@ -18,10 +18,10 @@ export type OtherKey =
 
 export type ContainerKey = 'zaino' | 'grid5x5' | OtherKey;
 
-export type ItemKind = 'alimento' | 'indumento' | 'arma' | 'generico';
+export type ItemKind = 'alimento' | 'risorsa' | 'arma';
 export type DamageType = 'contundente' | 'chimico' | 'termico' | 'perforante';
 
-type BaseMeta = { description: string; tier: 1 | 2 | 3; kind: ItemKind };
+type BaseMeta = { description: string; kind: ItemKind; tier?: 1 | 2 | 3 };
 type FoodMeta = BaseMeta & {
   kind: 'alimento';
   isGluten?: boolean;
@@ -30,21 +30,17 @@ type FoodMeta = BaseMeta & {
   isVegetable?: boolean;
   isAlcohol?: boolean;
   isDrugs?: boolean;
-  consumption?: 'mangiare' | 'bere';
+  isFood?: boolean;
+  isDrink?: boolean;
   effectPercent?: number;
-};
-type ClothingMeta = BaseMeta & {
-  kind: 'indumento';
-  protezione?: number;
-  effect?: string;
 };
 type WeaponMeta = BaseMeta & {
   kind: 'arma';
   danno?: number;
-  munizioni?: number;
+  projectiles?: string;
   damageType?: DamageType;
 };
-type GenericMeta = BaseMeta & { kind: 'generico' };
+type ResourceMeta = BaseMeta & { kind: 'risorsa' };
 
 export type Item = {
   id: string;
@@ -55,7 +51,7 @@ export type Item = {
   y: number;
   w: number;
   h: number;
-} & (FoodMeta | ClothingMeta | WeaponMeta | GenericMeta);
+} & (FoodMeta | WeaponMeta | ResourceMeta);
 
 /** ------ Context shape ------ */
 type InventoryContextValue = {

--- a/client/src/context/user.tsx
+++ b/client/src/context/user.tsx
@@ -20,6 +20,8 @@ export type User = {
   biofeedback: number;
   temperature: number;
   isRobot: number;
+  isGm: number;
+  isSick: number;
   energy: number;
   unlockedAreas: Array<[number, number]>;
   inventory: Array<any>;
@@ -149,6 +151,8 @@ export function UserProvider({ children }: PropsWithChildren<{}>) {
     biofeedback: 65,
     temperature: 22,
     isRobot: 0,
+    isGm: 0,
+    isSick: 0,
     energy: 80,
     inventory: [],
     unlockedAreas: [],
@@ -164,7 +168,7 @@ export function UserProvider({ children }: PropsWithChildren<{}>) {
       refresh,
       revision,
     }),
-    [user, devFallback, name, loading, error, refresh],
+    [user, devFallback, name, loading, error, refresh, revision],
   );
 
   return <UserContext.Provider value={value}>{children}</UserContext.Provider>;

--- a/client/src/hooks/useFauna.ts
+++ b/client/src/hooks/useFauna.ts
@@ -15,9 +15,15 @@ export type BaseItem = {
   tier3Cost: number;
   isGluten: boolean;
   isSugar: boolean;
-  isRedMeat: boolean;
+  isMeat: boolean;
+  isVegetable: boolean;
   isAlcohol: boolean;
-  isDrug: boolean;
+  isDrugs: boolean;
+  isFood: boolean;
+  isDrink: boolean;
+  effectPercent: number;
+  projectileType: string | null;
+  damageType: string | null;
   dmgModifier: number;
   inventoryHeight: number;
   inventoryWidth: number;
@@ -92,9 +98,15 @@ const defaultFauna: Fauna = {
     tier3Cost: 0,
     isGluten: false,
     isSugar: false,
-    isRedMeat: true,
+    isMeat: true,
+    isVegetable: false,
     isAlcohol: false,
-    isDrug: false,
+    isDrugs: false,
+    isFood: true,
+    isDrink: false,
+    effectPercent: 0,
+    projectileType: null,
+    damageType: null,
     dmgModifier: 0,
     inventoryHeight: 1,
     inventoryWidth: 1,

--- a/client/src/routes/crafting.tsx
+++ b/client/src/routes/crafting.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useMemo, useState, useRef } from "react";
-import { FaCubes, FaTshirt, FaFistRaised, FaAppleAlt, FaEraser, FaFillDrip, FaVial, FaSearch, FaCheck, FaSuitcase } from "react-icons/fa";
+import { FaCubes, FaFistRaised, FaAppleAlt, FaEraser, FaFillDrip, FaVial, FaSearch, FaCheck, FaSuitcase } from "react-icons/fa";
 import CommandStreamRight from "../components/commandstream-right";
+import { useUser } from "../context/user";
 
 // Catalog/recipe types
-type ItemType = "risorsa" | "indumento" | "arma" | "alimento";
+type ItemType = "risorsa" | "arma" | "alimento";
 type RecipePart = { name: string; count: number };
 type Craftable = {
   name: string;
@@ -15,7 +16,7 @@ type Craftable = {
 };
 
 // Inventory store types (subset aligned with routes/inventory)
-type InvItemKind = "alimento" | "indumento" | "arma" | "generico";
+type InvItemKind = "alimento" | "arma" | "risorsa";
 type InvItem = {
   id: string;
   name: string;
@@ -58,7 +59,7 @@ const CRAFTABLES: Craftable[] = [
   },
   {
     name: "Pelle Rinforzata",
-    type: "indumento",
+    type: "risorsa",
     icon: "/pelle.png",
     w: 2,
     h: 2,
@@ -92,7 +93,7 @@ const CRAFTABLES: Craftable[] = [
   // Debug items with various sizes
   {
     name: "Armatura Completa",
-    type: "indumento", 
+    type: "risorsa", 
     icon: "/pelle.png",
     w: 3,
     h: 4,
@@ -118,7 +119,7 @@ const CRAFTABLES: Craftable[] = [
   },
   {
     name: "Scudo Grande",
-    type: "indumento",
+    type: "risorsa",
     icon: "/roccia.png",
     w: 3,
     h: 3,
@@ -139,7 +140,7 @@ const CRAFTABLES: Craftable[] = [
   },
   {
     name: "Armatura Leggera",
-    type: "indumento",
+    type: "risorsa",
     icon: "/pelle.png",
     w: 2,
     h: 3,
@@ -192,7 +193,7 @@ const CRAFTABLES: Craftable[] = [
   },
   {
     name: "Armatura Pesante",
-    type: "indumento",
+    type: "risorsa",
     icon: "/roccia.png",
     w: 3,
     h: 4,
@@ -214,7 +215,7 @@ const CRAFTABLES: Craftable[] = [
   },
   {
     name: "Scudo Medio",
-    type: "indumento",
+    type: "risorsa",
     icon: "/roccia.png",
     w: 2,
     h: 2,
@@ -257,7 +258,7 @@ const CRAFTABLES: Craftable[] = [
   },
   {
     name: "Casco",
-    type: "indumento",
+    type: "risorsa",
     icon: "/roccia.png",
     w: 1,
     h: 1,
@@ -267,7 +268,7 @@ const CRAFTABLES: Craftable[] = [
   },
   {
     name: "Torre Scudo",
-    type: "indumento",
+    type: "risorsa",
     icon: "/roccia.png",
     w: 2,
     h: 4,
@@ -313,7 +314,7 @@ const slugify = (name: string) =>
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");
 
-const mapTypeToKind = (t: ItemType): InvItemKind => (t === "risorsa" ? "generico" : (t as InvItemKind));
+const mapTypeToKind = (t: ItemType): InvItemKind => t as InvItemKind;
 
 const loadInventories = (): InventoriesStore => {
   try {
@@ -406,6 +407,9 @@ function Slot({
 }
 
 export default function Crafting() {
+  const { user } = useUser();
+  const isGm = Boolean(user?.isGm);
+
   const [inventories, setInventories] = useState<InventoriesStore>(() => loadInventories());
   const [q, setQ] = useState("");
   const [filter, setFilter] = useState<ItemType | null>(null);
@@ -464,11 +468,14 @@ export default function Crafting() {
   // Mapping delle icone per ogni tipo di item
   const getIconForType = (type: ItemType) => {
     switch (type) {
-      case "risorsa": return <FaCubes />;
-      case "indumento": return <FaTshirt />;
-      case "arma": return <FaFistRaised />;
-      case "alimento": return <FaAppleAlt />;
-      default: return <FaCubes />;
+      case "risorsa":
+        return <FaCubes />;
+      case "arma":
+        return <FaFistRaised />;
+      case "alimento":
+        return <FaAppleAlt />;
+      default:
+        return <FaCubes />;
     }
   };
 
@@ -476,7 +483,14 @@ export default function Crafting() {
   const totalTiles = GRID_COLS * GRID_ROWS;
 
   // Debug helpers: fill inventory with test items to try crafting
-  function addItemToZaino(next: InventoriesStore, name: string, icon: string, w: number, h: number, kind: InvItemKind = "generico") {
+  function addItemToZaino(
+    next: InventoriesStore,
+    name: string,
+    icon: string,
+    w: number,
+    h: number,
+    kind: InvItemKind = "risorsa",
+  ) {
     const pos = findPlacement(next.zaino || [], w, h);
     if (!pos) return false;
     const id = `${slugify(name)}-${Math.random().toString(36).slice(2, 8)}`;
@@ -498,13 +512,14 @@ export default function Crafting() {
   }
 
   function fillInventoryForTest() {
+    if (!isGm) return;
     setInventories((prev) => {
       const next: InventoriesStore = { ...prev, zaino: [...(prev.zaino || [])] };
       // Try to place a variety of items until near capacity
       const batches: Array<{ name: string; icon: string; w: number; h: number; kind?: InvItemKind; count: number }> = [
-        { name: "Roccia", icon: "/roccia.png", w: 2, h: 2, kind: "generico", count: 6 },
-        { name: "Pelle", icon: "/pelle.png", w: 1, h: 1, kind: "indumento", count: 8 },
-        { name: "Ossa", icon: "/ossa.png", w: 1, h: 1, kind: "generico", count: 6 },
+        { name: "Roccia", icon: "/roccia.png", w: 2, h: 2, kind: "risorsa", count: 6 },
+        { name: "Pelle", icon: "/pelle.png", w: 1, h: 1, kind: "risorsa", count: 8 },
+        { name: "Ossa", icon: "/ossa.png", w: 1, h: 1, kind: "risorsa", count: 6 },
         { name: "Bastone Acuminato", icon: "/bastoneacuminato.png", w: 1, h: 5, kind: "arma", count: 1 },
       ];
       for (const b of batches) {
@@ -518,6 +533,7 @@ export default function Crafting() {
   }
 
   function clearZaino() {
+    if (!isGm) return;
     setInventories((prev) => ({ ...prev, zaino: [] }));
   }
 
@@ -965,7 +981,7 @@ export default function Crafting() {
             }}
           />
         </div>
-        {(["risorsa", "indumento", "arma", "alimento"] as ItemType[]).map((t) => (
+        {(["risorsa", "arma", "alimento"] as ItemType[]).map((t) => (
           <button
             key={t}
             onClick={() => setFilter((f) => (f === t ? null : t))}
@@ -1021,58 +1037,62 @@ export default function Crafting() {
           <FaEraser />
         </button>
         {/* Debug controls */}
-        <button 
-          onClick={fillInventoryForTest} 
-          className="filter-button"
-          style={{ 
-            padding: "12px",
-            width: "60px",
-            height: "60px",
-            border: "none",
-            cursor: "pointer",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            color: "#47a8bf",
-            fontSize: "20px",
-            opacity: 0.9,
-            transition: "all 0.2s ease",
-            backgroundColor: "transparent",
-            position: "relative",
-            zIndex: 1,
-          }}
-          title="Riempi inventario per test"
-          onMouseEnter={(e) => e.currentTarget.style.opacity = "1"}
-          onMouseLeave={(e) => e.currentTarget.style.opacity = "0.9"}
-        >
-          <FaFillDrip />
-        </button>
-        <button 
-          onClick={clearZaino} 
-          className="filter-button"
-          style={{ 
-            padding: "12px",
-            width: "60px",
-            height: "60px",
-            border: "none",
-            cursor: "pointer",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            color: "#bf4747",
-            fontSize: "20px",
-            opacity: 0.9,
-            transition: "all 0.2s ease",
-            backgroundColor: "transparent",
-            position: "relative",
-            zIndex: 1,
-          }}
-          title="Svuota zaino"
-          onMouseEnter={(e) => e.currentTarget.style.opacity = "1"}
-          onMouseLeave={(e) => e.currentTarget.style.opacity = "0.9"}
-        >
-          <FaVial />
-        </button>
+        {isGm && (
+          <>
+            <button
+              onClick={fillInventoryForTest}
+              className="filter-button"
+              style={{
+                padding: "12px",
+                width: "60px",
+                height: "60px",
+                border: "none",
+                cursor: "pointer",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                color: "#47a8bf",
+                fontSize: "20px",
+                opacity: 0.9,
+                transition: "all 0.2s ease",
+                backgroundColor: "transparent",
+                position: "relative",
+                zIndex: 1,
+              }}
+              title="Riempi inventario per test"
+              onMouseEnter={(e) => (e.currentTarget.style.opacity = "1")}
+              onMouseLeave={(e) => (e.currentTarget.style.opacity = "0.9")}
+            >
+              <FaFillDrip />
+            </button>
+            <button
+              onClick={clearZaino}
+              className="filter-button"
+              style={{
+                padding: "12px",
+                width: "60px",
+                height: "60px",
+                border: "none",
+                cursor: "pointer",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                color: "#bf4747",
+                fontSize: "20px",
+                opacity: 0.9,
+                transition: "all 0.2s ease",
+                backgroundColor: "transparent",
+                position: "relative",
+                zIndex: 1,
+              }}
+              title="Svuota zaino"
+              onMouseEnter={(e) => (e.currentTarget.style.opacity = "1")}
+              onMouseLeave={(e) => (e.currentTarget.style.opacity = "0.9")}
+            >
+              <FaVial />
+            </button>
+          </>
+        )}
       </div>
 
       {/* Spazio per scritta ALGORITMO-SURVIVAL-STATUS (nascosta) */}

--- a/client/src/routes/inventory.tsx
+++ b/client/src/routes/inventory.tsx
@@ -12,8 +12,8 @@ import {
 import { BACKEND_IP, BACKEND_PORT } from '../common';
 import { useUser } from '../context/user';
 
-type ItemKind = 'alimento' | 'indumento' | 'arma' | 'generico';
-type BaseMeta = { description: string; tier: 1 | 2 | 3; kind: ItemKind };
+type ItemKind = 'alimento' | 'risorsa' | 'arma';
+type BaseMeta = { description: string; kind: ItemKind; tier?: 1 | 2 | 3 };
 type FoodMeta = BaseMeta & {
   kind: 'alimento';
   isGluten?: boolean;
@@ -22,22 +22,18 @@ type FoodMeta = BaseMeta & {
   isVegetable?: boolean;
   isAlcohol?: boolean;
   isDrugs?: boolean;
-  consumption?: 'mangiare' | 'bere';
+  isFood?: boolean;
+  isDrink?: boolean;
   effectPercent?: number;
-};
-type ClothingMeta = BaseMeta & {
-  kind: 'indumento';
-  protezione?: number;
-  effect?: string;
 };
 type DamageType = 'contundente' | 'chimico' | 'termico' | 'perforante';
 type WeaponMeta = BaseMeta & {
   kind: 'arma';
   danno?: number;
-  munizioni?: number;
+  projectiles?: string;
   damageType?: DamageType;
 };
-type GenericMeta = BaseMeta & { kind: 'generico' };
+type ResourceMeta = BaseMeta & { kind: 'risorsa' };
 
 type Item = {
   id: string;
@@ -48,7 +44,7 @@ type Item = {
   y: number;
   w: number;
   h: number;
-} & (FoodMeta | ClothingMeta | WeaponMeta | GenericMeta);
+} & (FoodMeta | WeaponMeta | ResourceMeta);
 
 // ---- dynamic specs for "others" coming from backend ----
 type InvCategory = 'zaino' | 'cassa';
@@ -1229,13 +1225,17 @@ export default function Inventory() {
                     valueFontSize={VALUE_FS}
                     padding={PAD}
                   >
-                    {Array.from({ length: selectedItem.tier }).map((_, i) => (
-                      <FaStar
-                        key={i}
-                        color='#dfffff'
-                        style={{ marginLeft: 4 }}
-                      />
-                    ))}
+                    {selectedItem.tier ? (
+                      Array.from({ length: selectedItem.tier }).map((_, i) => (
+                        <FaStar
+                          key={i}
+                          color='#dfffff'
+                          style={{ marginLeft: 4 }}
+                        />
+                      ))
+                    ) : (
+                      <span style={{ fontWeight: 700 }}>—</span>
+                    )}
                   </Slot>
                   {selectedItem.kind === 'alimento' && (
                     <>
@@ -1281,61 +1281,39 @@ export default function Inventory() {
                         padding={PAD}
                       >
                         {typeof selectedItem.effectPercent === 'number' ? (
-                          <div
-                            style={{
-                              display: 'flex',
-                              alignItems: 'center',
-                              gap: 6,
-                            }}
-                          >
-                            {selectedItem.consumption === 'bere' ? (
-                              <img
-                                src='/droplet_fill.png'
-                                alt='Sete'
-                                width={ICON_SIZE}
-                                height={ICON_SIZE}
-                              />
-                            ) : (
-                              <img
-                                src='/stomach-fill.png'
-                                alt='Fame'
-                                width={ICON_SIZE}
-                                height={ICON_SIZE}
-                              />
-                            )}
-                            <span style={{ fontWeight: 700 }}>
-                              {selectedItem.effectPercent}%
-                            </span>
-                          </div>
+                          (() => {
+                            const drink = selectedItem.isDrink ?? false;
+                            const food = selectedItem.isFood ?? false;
+                            const hasIcon = drink || food;
+                            const iconSrc = drink
+                              ? '/droplet_fill.png'
+                              : '/stomach-fill.png';
+                            const iconAlt = drink ? 'Sete' : 'Fame';
+                            return (
+                              <div
+                                style={{
+                                  display: 'flex',
+                                  alignItems: 'center',
+                                  gap: 6,
+                                }}
+                              >
+                                {hasIcon ? (
+                                  <img
+                                    src={iconSrc}
+                                    alt={iconAlt}
+                                    width={ICON_SIZE}
+                                    height={ICON_SIZE}
+                                  />
+                                ) : null}
+                                <span style={{ fontWeight: 700 }}>
+                                  {selectedItem.effectPercent}%
+                                </span>
+                              </div>
+                            );
+                          })()
                         ) : (
                           <span style={{ fontWeight: 700 }}>—</span>
                         )}
-                      </Slot>
-                    </>
-                  )}
-                  {selectedItem.kind === 'indumento' && (
-                    <>
-                      <Slot
-                        label='Protezione'
-                        width={W}
-                        labelFontSize={LABEL_FS}
-                        valueFontSize={VALUE_FS}
-                        padding={PAD}
-                      >
-                        <span style={{ fontWeight: 700 }}>
-                          {selectedItem.protezione ?? 0}
-                        </span>
-                      </Slot>
-                      <Slot
-                        label='Effetto'
-                        width={W}
-                        labelFontSize={LABEL_FS}
-                        valueFontSize={VALUE_FS}
-                        padding={PAD}
-                      >
-                        <span style={{ fontWeight: 700 }}>
-                          {selectedItem.effect ?? '—'}
-                        </span>
                       </Slot>
                     </>
                   )}
@@ -1372,19 +1350,19 @@ export default function Inventory() {
                         </div>
                       </Slot>
                       <Slot
-                        label='Munizioni'
+                        label='Proiettili'
                         width={W}
                         labelFontSize={LABEL_FS}
                         valueFontSize={VALUE_FS}
                         padding={PAD}
                       >
                         <span style={{ fontWeight: 700 }}>
-                          {selectedItem.munizioni ?? 0}
+                          {selectedItem.projectiles ?? '—'}
                         </span>
                       </Slot>
                     </>
                   )}
-                  {selectedItem.kind === 'generico' && (
+                  {selectedItem.kind === 'risorsa' && (
                     <>
                       <Slot
                         label='Info'

--- a/client/src/routes/login.tsx
+++ b/client/src/routes/login.tsx
@@ -56,10 +56,17 @@ export default function LoginPage() {
     );
     if (response.ok) {
       setError(null);
+      let gmFlag = false;
+      try {
+        const data = await response.json();
+        gmFlag = !!(data as any)?.isGm;
+      } catch (err) {
+        console.warn('Impossibile leggere la risposta di login:', err);
+      }
       try {
         localStorage.setItem(
           'thebody.auth',
-          JSON.stringify({ user: username, t: Date.now() }),
+          JSON.stringify({ user: username, gm: gmFlag, t: Date.now() }),
         );
       } catch {}
       try {

--- a/client/src/routes/user.tsx
+++ b/client/src/routes/user.tsx
@@ -14,14 +14,14 @@ import {
   faLungs,
   faMoon,
   faHeartPulse,
-  faShirt,
   faGun,
   faRotateLeft,
+  faSuitcase,
 } from '@fortawesome/free-solid-svg-icons';
 // import MonitorWidget from "../components/monitorwidget"; // non usato qui, mostriamo soli valori
 
 // Minimal re-use of inventory item types and helpers (aligned with inventory/crafting)
-type InvItemKind = 'alimento' | 'indumento' | 'arma' | 'generico';
+type InvItemKind = 'alimento' | 'arma' | 'risorsa';
 type InvItem = {
   id: string;
   name: string;
@@ -159,7 +159,7 @@ export default function User({
           id: 'test-outfit-1',
           name: 'Tuta Spaziale',
           icon: '/zaino.png',
-          kind: 'indumento',
+          kind: 'risorsa',
           x: 0,
           y: 1,
           w: 2,
@@ -171,7 +171,7 @@ export default function User({
           id: 'test-outfit-2',
           name: 'Armatura',
           icon: '/pelle.png',
-          kind: 'indumento',
+          kind: 'risorsa',
           x: 2,
           y: 1,
           w: 2,
@@ -191,7 +191,7 @@ export default function User({
   const zaino = inventories.zaino || [];
   const weapons = useMemo(() => zaino.filter(i => i.kind === 'arma'), [zaino]);
   const outfits = useMemo(
-    () => zaino.filter(i => i.kind === 'indumento'),
+    () => zaino.filter(i => i.kind === 'risorsa'),
     [zaino],
   );
   const usedTiles = useMemo(
@@ -213,8 +213,8 @@ export default function User({
   function equipItem(slot: 'left' | 'right' | 'outfit', item: InvItem) {
     setError(null);
     // validate kind for slot
-    if (slot === 'outfit' && item.kind !== 'indumento') {
-      setError('Solo indumenti possono essere equipaggiati nello slot Outfit.');
+    if (slot === 'outfit' && item.kind !== 'risorsa') {
+      setError('Solo risorse compatibili possono essere equipaggiate nello slot Outfit.');
       return;
     }
     if ((slot === 'left' || slot === 'right') && item.kind !== 'arma') {
@@ -521,7 +521,7 @@ export default function User({
     item?: InvItem | null;
     onPick: () => void;
     onUnequip: () => void;
-    kind: 'arma' | 'indumento';
+    kind: 'arma' | 'risorsa';
   }) {
     return (
       <div
@@ -625,7 +625,7 @@ export default function User({
                 fontSize: 24,
               }}
             >
-              <FontAwesomeIcon icon={kind === 'arma' ? faGun : faShirt} />
+              <FontAwesomeIcon icon={kind === 'arma' ? faGun : faSuitcase} />
             </div>
             <div
               onMouseUp={e => {
@@ -857,7 +857,7 @@ export default function User({
           >
             <Slot
               label='Outfit'
-              kind='indumento'
+              kind='risorsa'
               item={equip.outfit}
               onPick={() => openPicker('outfit')}
               onUnequip={() => unequipItem('outfit')}
@@ -931,7 +931,7 @@ export default function User({
             >
               <strong>
                 Seleziona{' '}
-                {picker!.slot === 'outfit' ? 'un indumento' : "un'arma"}
+                {picker!.slot === 'outfit' ? 'una risorsa' : "un'arma"}
               </strong>
               <button
                 onClick={() => setPicker(null)}

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -10,6 +10,8 @@ export const playersTable = sqliteTable("players", {
   biofeedback: int().notNull().default(100),
   temperature: int().notNull().default(20),
   isRobot: int().notNull().default(0),
+  isGm: int().notNull().default(0),
+  isSick: int().notNull().default(0),
   energy: int().notNull().default(100),
   /**
    * JSON array of int[2], i.e. [[1, 1], [2, 3]]
@@ -41,6 +43,8 @@ export const baseItemsTable = sqliteTable("baseItems", {
     .notNull(),
   image: text().notNull(), // link (relativo) all'immagine, es. /img/items/egg
   description: text().notNull(), // Può contenere HTML
+  inventoryWidth: int().notNull(),
+  inventoryHeight: int().notNull(),
   tier1Value: int().default(0),
   tier1Cost: int().default(0),
   tier2Value: int().default(0),
@@ -49,12 +53,16 @@ export const baseItemsTable = sqliteTable("baseItems", {
   tier3Cost: int().default(0),
   isGluten: int().default(0),
   isSugar: int().default(0),
-  isRedMeat: int().default(0),
+  isMeat: int().default(0),
+  isVegetable: int().default(0),
   isAlcohol: int().default(0),
-  isDrug: int().default(0),
+  isDrugs: int().default(0),
+  isFood: int().default(0),
+  isDrink: int().default(0),
+  effectPercent: int().default(0),
+  projectileType: text(),
+  damageType: text(),
   dmgModifier: real().default(0),
-  inventoryHeight: int().notNull(),
-  inventoryWidth: int().notNull(),
 });
 
 export const itemsTable = sqliteTable("items", {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -11,6 +11,7 @@ import {
 import { eq } from "drizzle-orm";
 import { getDinosaurById } from "./dao/dinosaur";
 import { getInventoriesForUser } from "./routes/inventories";
+import { registerGameMasterRoutes } from "./routes/gm";
 
 const fastify = Fastify({
   logger: true,
@@ -25,6 +26,8 @@ fastify.register(cors, {
 const wsManager = new WebsocketManager();
 
 fastify.register(async function (fastify) {
+  registerGameMasterRoutes(fastify, wsManager);
+
   fastify.get("/ws", { websocket: true }, (connection, req) => {
     const url = new URL(req.url, "http://localhost");
     const name = url.searchParams.get("name");
@@ -53,7 +56,7 @@ fastify.register(async function (fastify) {
       return;
     }
 
-    res.code(200).send();
+    res.code(200).send({ isGm: !!users[0].isGm });
     return;
   });
 

--- a/server/src/routes/gm.ts
+++ b/server/src/routes/gm.ts
@@ -1,0 +1,503 @@
+import { FastifyInstance } from "fastify";
+import { eq } from "drizzle-orm";
+
+import { db } from "../db";
+import {
+  baseItemsTable,
+  playersTable,
+} from "../db/schema";
+import { WebsocketManager } from "../ws/handler";
+
+type PlayerRow = typeof playersTable.$inferSelect;
+type BaseItemRow = typeof baseItemsTable.$inferSelect;
+
+type InventoryItem = {
+  id: string;
+  name: string;
+  icon: string;
+  image?: string;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  kind?: string;
+  description?: string;
+  tier?: number;
+  isGluten?: boolean;
+  isSugar?: boolean;
+  isMeat?: boolean;
+  isVegetable?: boolean;
+  isAlcohol?: boolean;
+  isDrugs?: boolean;
+  isFood?: boolean;
+  isDrink?: boolean;
+  effectPercent?: number;
+  projectiles?: string | null;
+  damageType?: string | null;
+  dmgModifier?: number;
+};
+
+const GRID_COLS = 10;
+const GRID_ROWS = 7;
+
+const clamp = (value: number, min = 0, max = 100) =>
+  Math.min(max, Math.max(min, value));
+
+const parseInventory = (raw: string | null | undefined): InventoryItem[] => {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) return parsed as InventoryItem[];
+  } catch (err) {
+    console.warn("Failed to parse inventory", err);
+  }
+  return [];
+};
+
+const serializeInventory = (items: InventoryItem[]) => JSON.stringify(items ?? []);
+
+function hasOverlap(
+  items: InventoryItem[],
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+) {
+  return items.some(item => {
+    if (item.x === undefined || item.y === undefined) return false;
+    const horizontal = x < item.x + item.w && x + w > item.x;
+    const vertical = y < item.y + item.h && y + h > item.y;
+    return horizontal && vertical;
+  });
+}
+
+function findPlacement(items: InventoryItem[], w: number, h: number) {
+  for (let yy = 0; yy <= GRID_ROWS - h; yy += 1) {
+    for (let xx = 0; xx <= GRID_COLS - w; xx += 1) {
+      if (!hasOverlap(items, xx, yy, w, h)) {
+        return { x: xx, y: yy };
+      }
+    }
+  }
+  return null;
+}
+
+async function requireGm(name: string) {
+  const result = await db
+    .select()
+    .from(playersTable)
+    .where(eq(playersTable.name, name));
+
+  if (!result.length || !result[0].isGm) {
+    const error = new Error("Forbidden");
+    (error as any).statusCode = 403;
+    throw error;
+  }
+
+  return result[0];
+}
+
+async function getTargets(target: string | undefined) {
+  if (!target) {
+    const error = new Error("Missing target");
+    (error as any).statusCode = 400;
+    throw error;
+  }
+
+  if (target.toLowerCase() === "all") {
+    return db.select().from(playersTable);
+  }
+
+  const players = await db
+    .select()
+    .from(playersTable)
+    .where(eq(playersTable.name, target));
+  if (!players.length) {
+    const error = new Error("Player not found");
+    (error as any).statusCode = 404;
+    throw error;
+  }
+  return players;
+}
+
+async function updatePlayer(player: PlayerRow, values: Partial<PlayerRow>) {
+  await db
+    .update(playersTable)
+    .set(values)
+    .where(eq(playersTable.name, player.name));
+}
+
+async function giveItemToPlayer(
+  player: PlayerRow,
+  item: BaseItemRow,
+  amount: number,
+) {
+  const inventory = parseInventory(player.inventory);
+
+  const placement = findPlacement(
+    inventory,
+    item.inventoryWidth ?? 1,
+    item.inventoryHeight ?? 1,
+  );
+
+  if (!placement) {
+    const error = new Error(`Inventario pieno per ${player.name}`);
+    (error as any).statusCode = 409;
+    throw error;
+  }
+
+  const now = Date.now();
+  const entries: InventoryItem[] = [];
+  for (let i = 0; i < amount; i += 1) {
+    const nextPlacement =
+      i === 0
+        ? placement
+        : findPlacement(
+            [...inventory, ...entries],
+            item.inventoryWidth ?? 1,
+            item.inventoryHeight ?? 1,
+          );
+
+    if (!nextPlacement) break;
+
+    entries.push({
+      id: `${item.id}-${now}-${i}-${Math.random().toString(36).slice(2, 6)}`,
+      name: item.name,
+      icon: item.image,
+      image: item.image,
+      x: nextPlacement.x,
+      y: nextPlacement.y,
+      w: item.inventoryWidth ?? 1,
+      h: item.inventoryHeight ?? 1,
+      kind: item.type ?? undefined,
+      description: item.description,
+      tier: 1,
+      isGluten: !!item.isGluten,
+      isSugar: !!item.isSugar,
+      isMeat: !!item.isMeat,
+      isVegetable: !!item.isVegetable,
+      isAlcohol: !!item.isAlcohol,
+      isDrugs: !!item.isDrugs,
+      isFood: !!item.isFood,
+      isDrink: !!item.isDrink,
+      effectPercent: item.effectPercent ?? undefined,
+      projectiles: item.projectileType ?? null,
+      damageType: item.damageType ?? null,
+      dmgModifier: item.dmgModifier ?? undefined,
+    });
+  }
+
+  if (!entries.length) {
+    const error = new Error(`Impossibile posizionare l'oggetto in ${player.name}`);
+    (error as any).statusCode = 409;
+    throw error;
+  }
+
+  const updated = [...inventory, ...entries];
+
+  await db
+    .update(playersTable)
+    .set({ inventory: serializeInventory(updated) })
+    .where(eq(playersTable.name, player.name));
+
+  return entries.length;
+}
+
+type CommandResult = { message: string };
+
+async function handleCommand(
+  gm: PlayerRow,
+  command: string,
+): Promise<CommandResult> {
+  const tokens = command.trim().split(/\s+/);
+  if (!tokens.length || !tokens[0]) {
+    throw Object.assign(new Error("Comando non valido"), { statusCode: 400 });
+  }
+
+  const verb = tokens[0].toLowerCase();
+
+  const amountArg = tokens[2] ? Number(tokens[2]) : undefined;
+
+  const ensureAmount = () => {
+    if (Number.isNaN(amountArg!)) {
+      throw Object.assign(new Error("Valore numerico non valido"), {
+        statusCode: 400,
+      });
+    }
+    return amountArg!;
+  };
+
+  const target = tokens[1];
+
+  switch (verb) {
+    case "_dmg": {
+      const amt = ensureAmount();
+      const targets = await getTargets(target);
+      for (const player of targets) {
+        await updatePlayer(player, {
+          biofeedback: clamp((player.biofeedback ?? 0) - amt),
+        });
+      }
+      return { message: `Inflitti ${amt} danni a ${target}` };
+    }
+    case "_heal": {
+      const amt = ensureAmount();
+      const targets = await getTargets(target);
+      for (const player of targets) {
+        await updatePlayer(player, {
+          biofeedback: clamp((player.biofeedback ?? 0) + amt),
+        });
+      }
+      return { message: `Cura di ${amt} punti eseguita per ${target}` };
+    }
+    case "_f": {
+      const amt = ensureAmount();
+      const targets = await getTargets(target);
+      for (const player of targets) {
+        await updatePlayer(player, {
+          hunger: clamp((player.hunger ?? 0) + amt),
+        });
+      }
+      return { message: `Fame modificata di ${amt} per ${target}` };
+    }
+    case "_s": {
+      const amt = ensureAmount();
+      const targets = await getTargets(target);
+      for (const player of targets) {
+        await updatePlayer(player, {
+          thirst: clamp((player.thirst ?? 0) + amt),
+        });
+      }
+      return { message: `Sete modificata di ${amt} per ${target}` };
+    }
+    case "_so": {
+      const amt = ensureAmount();
+      const targets = await getTargets(target);
+      for (const player of targets) {
+        await updatePlayer(player, {
+          sleep: clamp((player.sleep ?? 0) + amt),
+        });
+      }
+      return { message: `Sonno modificato di ${amt} per ${target}` };
+    }
+    case "_e": {
+      const amt = ensureAmount();
+      const targets = await getTargets(target);
+      for (const player of targets) {
+        await updatePlayer(player, {
+          energy: clamp((player.energy ?? 0) + amt),
+        });
+      }
+      return { message: `Energia modificata di ${amt} per ${target}` };
+    }
+    case "_quickstrangle": {
+      const targets = await getTargets(target);
+      for (const player of targets) {
+        await updatePlayer(player, { oxygen: clamp(0) });
+      }
+      return { message: `Ossigeno azzerato rapidamente per ${target}` };
+    }
+    case "_slowstrangle": {
+      const targets = await getTargets(target);
+      for (const player of targets) {
+        const newOxygen = clamp((player.oxygen ?? 0) - 50);
+        await updatePlayer(player, { oxygen: newOxygen });
+      }
+      return { message: `Ossigeno ridotto lentamente per ${target}` };
+    }
+    case "ill": {
+      const targets = await getTargets(target);
+      for (const player of targets) {
+        await updatePlayer(player, { isSick: 1 });
+      }
+      return { message: `${target} ammalato` };
+    }
+    case "fix": {
+      const targets = await getTargets(target);
+      for (const player of targets) {
+        await updatePlayer(player, { isSick: 0 });
+      }
+      return { message: `${target} curato` };
+    }
+    case "give": {
+      const amount = tokens[3] ? Number(tokens[3]) : 1;
+      if (Number.isNaN(amount) || amount <= 0) {
+        throw Object.assign(new Error("Quantità non valida"), {
+          statusCode: 400,
+        });
+      }
+      if (!target || !tokens[2]) {
+        throw Object.assign(new Error("Sintassi give [player] [item]"), {
+          statusCode: 400,
+        });
+      }
+      const players = await getTargets(target);
+      const itemName = tokens[2];
+      const baseItems = await db
+        .select()
+        .from(baseItemsTable)
+        .where(eq(baseItemsTable.name, itemName));
+
+      if (!baseItems.length) {
+        throw Object.assign(new Error(`Item ${itemName} non trovato`), {
+          statusCode: 404,
+        });
+      }
+
+      const granted = [] as Array<{ name: string; count: number }>;
+      for (const player of players) {
+        const count = await giveItemToPlayer(player, baseItems[0], amount || 1);
+        granted.push({ name: player.name, count });
+      }
+
+      const message = granted
+        .map(entry => `${entry.count}x ${itemName} a ${entry.name}`)
+        .join(", ");
+      return { message: message || "Nessun oggetto consegnato" };
+    }
+    case "sack": {
+      const players = await getTargets(target);
+      for (const player of players) {
+        await updatePlayer(player, { inventory: serializeInventory([]) });
+      }
+      return { message: `Inventario svuotato per ${target}` };
+    }
+    case "_newday": {
+      const players = await db.select().from(playersTable);
+      for (const player of players) {
+        if (player.isRobot) {
+          await updatePlayer(player, {
+            energy: clamp((player.energy ?? 0) - 25),
+          });
+        } else {
+          const next: Partial<PlayerRow> = {
+            hunger: clamp((player.hunger ?? 0) - 25),
+            thirst: clamp((player.thirst ?? 0) - 25),
+            sleep: clamp((player.sleep ?? 0) - 25),
+          };
+          if (!player.isSick) {
+            next.biofeedback = 100;
+          }
+          await updatePlayer(player, next);
+        }
+      }
+      return { message: "Nuovo giorno applicato" };
+    }
+    default:
+      throw Object.assign(new Error(`Comando sconosciuto: ${verb}`), {
+        statusCode: 400,
+      });
+  }
+}
+
+export function registerGameMasterRoutes(
+  fastify: FastifyInstance,
+  wsManager: WebsocketManager,
+) {
+  fastify.get("/gm/state", async (req, res) => {
+    const name = (req.query as { name?: string }).name;
+    if (!name) {
+      res.code(400).send({ error: "Missing name" });
+      return;
+    }
+
+    await requireGm(name);
+
+    const players = await db.select().from(playersTable);
+
+    const payload = players.map(player => ({
+      name: player.name,
+      hunger: player.hunger,
+      thirst: player.thirst,
+      sleep: player.sleep,
+      oxygen: player.oxygen,
+      energy: player.energy,
+      biofeedback: player.biofeedback,
+      temperature: player.temperature,
+      isRobot: player.isRobot,
+      isSick: player.isSick,
+      inventory: parseInventory(player.inventory),
+    }));
+
+    res.send({ players: payload });
+  });
+
+  fastify.post("/gm/command", async (req, res) => {
+    const body = req.body as { name?: string; command?: string };
+    if (!body?.name || !body?.command) {
+      res.code(400).send({ error: "Parametri mancanti" });
+      return;
+    }
+
+    const gm = await requireGm(body.name);
+
+    try {
+      const result = await handleCommand(gm, body.command);
+      wsManager.sendToAll(Buffer.from("update"));
+      res.send({ ok: true, message: result.message });
+    } catch (err) {
+      const status = (err as any).statusCode ?? 500;
+      res.code(status).send({ error: (err as Error).message });
+    }
+  });
+
+  fastify.post("/gm/transfer", async (req, res) => {
+    const body = req.body as { name?: string; from?: string; itemId?: string };
+    if (!body?.name || !body?.from || !body?.itemId) {
+      res.code(400).send({ error: "Parametri mancanti" });
+      return;
+    }
+
+    const gm = await requireGm(body.name);
+
+    const [fromPlayer] = await db
+      .select()
+      .from(playersTable)
+      .where(eq(playersTable.name, body.from));
+    if (!fromPlayer) {
+      res.code(404).send({ error: "Giocatore sorgente non trovato" });
+      return;
+    }
+
+    const [gmPlayer] = await db
+      .select()
+      .from(playersTable)
+      .where(eq(playersTable.name, gm.name));
+
+    const sourceInventory = parseInventory(fromPlayer.inventory);
+    const itemIndex = sourceInventory.findIndex(item => item.id === body.itemId);
+    if (itemIndex === -1) {
+      res.code(404).send({ error: "Item non trovato" });
+      return;
+    }
+
+    const item = sourceInventory[itemIndex];
+    const updatedSource = [...sourceInventory];
+    updatedSource.splice(itemIndex, 1);
+
+    const gmInventory = parseInventory(gmPlayer.inventory);
+    const placement = findPlacement(gmInventory, item.w ?? 1, item.h ?? 1);
+    if (!placement) {
+      res.code(409).send({ error: "Inventario GM pieno" });
+      return;
+    }
+
+    const movedItem = { ...item, x: placement.x, y: placement.y };
+
+    await db
+      .update(playersTable)
+      .set({ inventory: serializeInventory(updatedSource) })
+      .where(eq(playersTable.name, fromPlayer.name));
+
+    await db
+      .update(playersTable)
+      .set({
+        inventory: serializeInventory([...gmInventory, movedItem]),
+      })
+      .where(eq(playersTable.name, gmPlayer.name));
+
+    wsManager.sendToAll(Buffer.from("update"));
+
+    res.send({ ok: true, message: `Item trasferito da ${fromPlayer.name}` });
+  });
+}


### PR DESCRIPTION
## Summary
- add dedicated game-master routes for commands, player state polling, and inventory transfers tied to GM authentication
- extend player schema and auth flow to surface GM and sickness flags to the client
- introduce a GM overlay UI with terminal, remote vitals dashboard, and gated crafting debug actions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e0192bd4f0832c810c36d2a7a75133